### PR TITLE
Fix X-Spam-Status header parse

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -328,7 +328,7 @@ class authres_status extends rcube_plugin
                     $results = end($results); // Should we take first or last header found? Last has probably been added by our own MTA
                 }
 
-                if (preg_match_all('/DKIM_[^,]+/', $results, $m)) {
+                if (preg_match_all('/DKIM_[^,=]+/', $results, $m)) {
                     if (array_search('DKIM_SIGNED', $m[0]) !== FALSE) {
                         if (array_search('DKIM_VALID', $m[0]) !== FALSE) {
                             if (array_search('DKIM_VALID_AU', $m[0])) {


### PR DESCRIPTION
If SpamAssassin X-Spam-Status header contains not just the names of the tests but the scores too (_TESTSSCORES_ macro in add_header config variable) we have to strip the score when parsing the header.