### PR TITLE
Add authres_permitpartialpass option

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -474,7 +474,7 @@ class authres_status extends rcube_plugin
 
         // at least one auth method was passed, show partial pass
         $rcmail = rcmail::get_instance();
-        if (($status & self::STATUS_PASS) && $rcmail->config->get('authres_permitpartialpass', true)) {
+        if (($status & self::STATUS_PASS) && ($status & self::STATUS_FAIL) && $rcmail->config->get('authres_permitpartialpass', true)) {
             $status = self::STATUS_PARS;
         } 
 

--- a/authres_status.php
+++ b/authres_status.php
@@ -472,6 +472,12 @@ class authres_status extends rcube_plugin
             }
         }
 
+        // at least one auth method was passed, show partial pass
+        $rcmail = rcmail::get_instance();
+        if (($status & self::STATUS_PASS) && $rcmail->config->get('authres_permitpartialpass', true)) {
+            $status = self::STATUS_PARS;
+        } 
+
         if ($status == self::STATUS_NOSIG) {
             $image = 'status_nosig.png';
             $alt = 'nosignature';
@@ -481,22 +487,18 @@ class authres_status extends rcube_plugin
         } elseif ($status == self::STATUS_PASS) {
             $image = 'status_pass.png';
             $alt = 'signaturepass';
-        } else {
-            // at least one auth method was passed, show partial pass
-            if (($status & self::STATUS_PASS)) {
-                $status = self::STATUS_PARS;
-                $image = 'status_partial_pass.png';
-                $alt = 'partialpass';
-            } elseif ($status >= self::STATUS_FAIL) {
-                $image = 'status_fail.png';
-                $alt = 'invalidsignature';
-            } elseif ($status >= self::STATUS_WARN) {
-                $image = 'status_warn.png';
-                $alt = 'temporaryinvalid';
-            } elseif ($status >= self::STATUS_THIRD) {
-                $image = 'status_third.png';
-                $alt = 'thirdparty';
-            }
+        } elseif ($status == self::STATUS_PARS) {
+            $image = 'status_partial_pass.png';
+            $alt = 'partialpass';
+        } elseif ($status >= self::STATUS_FAIL) {
+            $image = 'status_fail.png';
+            $alt = 'invalidsignature';
+        } elseif ($status >= self::STATUS_WARN) {
+            $image = 'status_warn.png';
+            $alt = 'temporaryinvalid';
+        } elseif ($status >= self::STATUS_THIRD) {
+            $image = 'status_third.png';
+            $alt = 'thirdparty';
         }
 
         if (!$show_statuses || ($show_statuses & $status)) {


### PR DESCRIPTION
This option will make any authres_status return FAIL if any authres result fails

For cases where spf=pass and dkim=pass and dmarc=fail and you don't want to show partialsuccess (green icon).

Change is backwards compatible.