### PR TITLE
fix: use of now removed rcube->imap to storage

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -433,7 +433,7 @@ class authres_status extends rcube_plugin
                         }
 
                         try {
-                          $dkimVerify = new DKIM_Verify($rcmail->imap->get_raw_body($uid));
+                          $dkimVerify = new DKIM_Verify($rcmail->storage->get_raw_body($uid));
                           $results = $dkimVerify->validate();
                         } catch(Exception $e) {
                           $results = array();


### PR DESCRIPTION
https://github.com/roundcube/roundcubemail/commit/aac9b696b8435c34c542e47877a3644a16a6f4f2#diff-b005448018b8820fb5901c83898cf76fb305d8c132d51fb130731711062f82ab

This created php Fatal errors on the latest 1.6.1 roundcube :
```
PHP Fatal error:  Uncaught Error: Call to a member function get_raw_body() on null in /apps/mail/roundcube/plugins/authres_status/authres_status.php:436
```