### PR TITLE
fix: added opendmarc support

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -356,7 +356,7 @@ class authres_status extends rcube_plugin
                         $authorDomainFound = false;
 
                         foreach ($results as $result) {
-                            if ($result['method'] == 'dkim' || $result['method'] == 'domainkeys') {
+                            if (in_array($result['method'], array('dkim', 'dmarc', 'domainkeys'))) {
                                 if (is_array($result['props']) && isset($result['props']['header'])) {
                                     $pvalue = '';
 
@@ -365,7 +365,9 @@ class authres_status extends rcube_plugin
                                         $pvalue = $result['props']['header']['d'];
                                     } elseif (isset($result['props']['header']['i'])) {
                                         $pvalue = substr($result['props']['header']['i'], strpos($result['props']['header']['i'], '@') + 1);
-                                    }
+                                    } elseif (isset($result['props']['header']['from'])) {
+                                        $pvalue = $result['props']['header']['from'];
+				    }
 
                                     if ($pvalue == $authorDomain || substr($authorDomain, -1 * strlen($pvalue)) == $pvalue) {
                                         $authorDomainFound = true;


### PR DESCRIPTION
The plugin wasn't able to pick up the 'header.from' section of Authentication-Results provided by opendmarc, leaving the `$title` blank, meaning alt text just ended with "verified by "

Example of header provided by opendmarc:
`Authentication-Results: example.com dmarc=pass (p=none dis=none) header.from=gmail.com`