### PR TITLE
Ignore A-R: "arc=none"

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -307,6 +307,10 @@ class authres_status extends rcube_plugin
                             'props'  => array()
                         );
 
+                        if (($parsed_resinfo['method'] == 'arc') && ($parsed_resinfo['result'] == 'none')) {
+                                continue;
+                        }
+
                         $propspec = trim(($m[0][1] > 0 ? substr($resinfo, 0, $m[0][1]) : '') . substr($resinfo, strlen($m[0][0])));
                         if ($propspec) {
                             if (preg_match_all('/(' . implode("|", self::$RFC5451_ptypes) . ')' . $cfws . '\.' . $cfws . '(' . implode("|", self::$RFC5451_properties) . ')' . $cfws . '=' . $cfws . '([^\s]*)/i', $propspec, $m)) {


### PR DESCRIPTION
When ARC verification is enabled in Exim 4.96, it always adds `arc=none` to the `Authentication-Results:` header if the message is not ARC signed, along with the spf and dkim results:

Example:

```
Authentication-Results: turing.lentil.org;
    iprev=pass (a3-13.smtp-out.eu-west-1.amazonses.com) smtp.remote-ip=54.240.3.13;
    spf=pass smtp.mailfrom=eu-west-1.amazonses.com;
    dkim=pass header.d=opportunityhub.open.ac.uk header.s=kxf57gyzklfaei26rmmnqdgqpjannfyi header.a=rsa-sha256;
    dkim=pass header.d=amazonses.com header.s=uku4taia5b5tsbglxyj6zym32efj7xqv header.a=rsa-sha256;
    arc=none
```

This causes authres_status to always report an invalid signature.

This patch ignores `arc=none`, so if the message does not contain any ARC signature but is otherwise valid DKIM etc. It will report a valid signature.