### PR TITLE
Ignore any result=none if status=pass

### DIFF
--- a/authres_status.php
+++ b/authres_status.php
@@ -520,7 +520,7 @@ class authres_status extends rcube_plugin
         } elseif ($status == self::STATUS_NORES) {
             $image = 'status_nores.png';
             $alt = 'noauthresults';
-        } elseif ($status == self::STATUS_PASS) {
+        } elseif (($status == self::STATUS_PASS) || ($status == self::STATUS_PASS + self::STATUS_NOSIG)) {
             $image = 'status_pass.png';
             $alt = 'signaturepass';
         } else {


### PR DESCRIPTION
Another go at https://github.com/pimlie/authres_status/pull/70

Move check from the rfc5451_extract_authresheader() header parsing to status check logic.

